### PR TITLE
Fix the style of VDatePicker

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -19,7 +19,7 @@ body,
 
 body {
   margin: 0;
-  font: 16px/24px 'Helvetica Neue', 'Roboto', 'Arial', sans-serif;
+  font: 16px/1.5 'Helvetica Neue', 'Roboto', 'Arial', sans-serif;
   background-color: #f5f5f5;
   color: #424242;
 }

--- a/src/components/VDatePicker/VDatePicker.vue
+++ b/src/components/VDatePicker/VDatePicker.vue
@@ -20,8 +20,11 @@ export default defineComponent({
 
 <style scoped>
 .datePicker {
-  border: 1px solid #ccc;
+  font: 16px/1.5 'Helvetica Neue', 'Roboto', 'Arial', sans-serif;
+  border: 1px solid #bdbdbd;
   height: 2rem;
+  width: 11.5rem;
+  padding: 0 0.5rem 0 2rem;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
This improves the style of VDatePicker.

Before: ![image](https://user-images.githubusercontent.com/1706782/111892276-3dd5ec00-8a3d-11eb-9843-ceca673babf6.png)

After: 
![image](https://user-images.githubusercontent.com/1706782/111892286-534b1600-8a3d-11eb-8dd1-8343639b81ae.png)
